### PR TITLE
Implement .del, allow for garbage collection

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,6 +169,10 @@ Log.prototype.entry = function(peer, seq, opts, cb) {
   this.db.get(encodeKey(peer, seq), opts, cb)
 }
 
+Log.prototype.del = function(peer, seq, cb) {
+  this.db.del(encodeKey(peer, seq), cb)
+}
+
 Log.prototype.append = function(entry, cb) {
   if (this.corked) return this._wait(this.append, arguments, false)
   if (!cb) cb = noop

--- a/index.js
+++ b/index.js
@@ -362,9 +362,11 @@ Log.prototype._tail = function(head, opts) {
     }
 
     self.db.get(encodeKey(h.peer, h.seq+1), {valueEncoding:opts.valueEncoding}, function(err, data) {
-      if (err) return cb(err)
+      if (err && !err.notFound) return cb(err)
 
       h.seq++
+
+      if (! data) return read(size, cb)
 
       var change = {
         peer: h.peer,

--- a/test.js
+++ b/test.js
@@ -153,3 +153,19 @@ tape('get entry', function(t) {
 
   a.append(new Buffer('hello world'))
 })
+
+tape('del entry', function(t) {
+  var a = init()
+
+  a.on('append', function(data) {
+    a.del(data.peer, data.seq, function(err) {
+      t.error(err, 'no err')
+      a.entry(data.peer, data.seq, function(err, entry) {
+        t.ok(err && err.notFound, 'error is not found')
+        t.end()
+      })
+    })
+  })
+
+  a.append(new Buffer('hello world'))
+})


### PR DESCRIPTION
This PR contains 2 modifications
1. Add the .del method, allows to delete an entry with peer/seq
2. read streams now support the case in which entries have been deleted
